### PR TITLE
fix: modal in landing page was rendering twice

### DIFF
--- a/client/src/containers/Modal.tsx
+++ b/client/src/containers/Modal.tsx
@@ -10,12 +10,11 @@ interface Props {
 }
 
 const Modal: React.FC<Props> = ({ children }: Props) => {
-  const portalDiv = document.getElementById('portal');
-  if (!portalDiv) return null;
-
-  const dispatch = useAppDispatch();
   const modal = useAppSelector((state) => state.modal.value);
-  if (!modal) return null;
+  const dispatch = useAppDispatch();
+
+  const portalDiv = document.getElementById('portal');
+  if (!portalDiv || !modal) return null;
 
   const handleClick = () => {
     dispatch(closeModal());

--- a/client/src/containers/NavBar.tsx
+++ b/client/src/containers/NavBar.tsx
@@ -5,9 +5,6 @@ import { Link } from 'react-router-dom';
 import { openModal } from '../redux/modalSlice';
 import { useAppDispatch } from '../redux/hooks';
 
-import UserLogin from '../pages/UserLogin';
-import Modal from '../containers/Modal';
-
 const NavBar: React.FC = () => {
   const dispatch = useAppDispatch();
 
@@ -21,9 +18,6 @@ const NavBar: React.FC = () => {
       <a style={{ cursor: 'pointer' }} onClick={handleClick}>
         Sign In
       </a>
-      <Modal>
-        <UserLogin />
-      </Modal>
     </nav>
   );
 };


### PR DESCRIPTION
Presence of modal in the LandingPage and NavBar made the modal content render twice. Removed the Modal component instance from the NavBar but left the handleClick event to bring up the modal from the LandingPage.